### PR TITLE
Drop PHP 7.4 support; update Alley domain; mark version 2.0.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 7.4 ]
+        php: [ 8.0 ]
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.1, 8.0, 7.4 ]
+        php: [ 8.2, 8.1, 8.0 ]
         wp_version: [ "latest" ]
         can_fail: [ false ]
         multisite: [ 0,1 ]

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 /**
  * PHP-CS-Fixer configuration
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
-Nothing yet.
+### Removed
+
+- PHP 7.4 support.
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.0.0
+
 ### Removed
 
 - PHP 7.4 support.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "authors": [
     {
       "name": "Alley",
-      "email": "info@alley.co"
+      "email": "info@alley.com"
     }
   ],
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "php": "^8.0"
   },
   "require-dev": {
-    "alleyinteractive/alley-coding-standards": "^0.3",
+    "alleyinteractive/alley-coding-standards": "^1.0.0",
     "friendsofphp/php-cs-fixer": "^3.8",
-    "mantle-framework/testkit": "^0.5"
+    "mantle-framework/testkit": "^0.9"
   },
   "scripts": {
     "fixer": "php-cs-fixer -v fix --allow-risky=yes",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "lock": false
   },
   "require": {
-    "php": "^7.4 || ^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3",

--- a/src/alley/wp/find-one.php
+++ b/src/alley/wp/find-one.php
@@ -2,7 +2,7 @@
 /**
  * `find_one()` functions
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/alley/wp/find-result.php
+++ b/src/alley/wp/find-result.php
@@ -2,7 +2,7 @@
 /**
  * `find_result()` function
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/fixtures/class-noop.php
+++ b/tests/alley/wp/fixtures/class-noop.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Noop
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-find-one.php
+++ b/tests/alley/wp/test-find-one.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Find_One
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/alley/wp/test-find-result.php
+++ b/tests/alley/wp/test-find-result.php
@@ -2,7 +2,7 @@
 /**
  * Class file for Test_Find_Result
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap
  *
- * (c) Alley <info@alley.co>
+ * (c) Alley <info@alley.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
## Summary

As titled.

## Notes for reviewers

None.

## Changelog entries

### Added

### Changed

### Deprecated

### Removed

- PHP 7.4 support.

### Fixed

### Security
